### PR TITLE
Pass all arguments to twig filter

### DIFF
--- a/src/Bridge/Twig/TruncateExtension.php
+++ b/src/Bridge/Twig/TruncateExtension.php
@@ -53,9 +53,9 @@ class TruncateExtension extends \Twig_Extension
      *
      * @return string
      */
-    public function truncateHTML($string, $length = 100)
+    public function truncateHTML(...$args)
     {
-        return $this->truncateService->truncate($string, $length);
+        return call_user_func_array([$this->truncateService, 'truncate'], $args);
     }
 
     /**


### PR DESCRIPTION
This pass _all_ arguments from the twig filter on to the truncate method.